### PR TITLE
Add ArgsUsage to some commands

### DIFF
--- a/label.go
+++ b/label.go
@@ -13,8 +13,9 @@ import (
 
 var (
 	showLabelsCommand = cli.Command{
-		Name:  "show-labels",
-		Usage: "output labels for a project suitable for use in config",
+		Name:      "show-labels",
+		Usage:     "output labels for a project suitable for use in config",
+		ArgsUsage: "[project]",
 		Action: func(c *cli.Context) {
 			opts, err := NewOptions(c)
 			if err != nil {
@@ -29,8 +30,9 @@ var (
 		},
 	}
 	setLabelsCommand = cli.Command{
-		Name:  "set-labels",
-		Usage: "set labels for a project based on our config",
+		Name:      "set-labels",
+		Usage:     "set labels for a project based on our config",
+		ArgsUsage: "[project]",
 		Action: func(c *cli.Context) {
 			opts, err := NewOptions(c)
 			if err != nil {

--- a/milestone.go
+++ b/milestone.go
@@ -29,8 +29,9 @@ var (
 		},
 	}
 	setMilestonesCommand = cli.Command{
-		Name:  "set-milestones",
-		Usage: "set milestones for a project based on our config",
+		Name:      "set-milestones",
+		Usage:     "set milestones for a project based on our config",
+		ArgsUsage: "[project]",
 		Action: func(c *cli.Context) {
 			opts, err := NewOptions(c)
 			if err != nil {
@@ -45,8 +46,9 @@ var (
 		},
 	}
 	createMilestoneCommand = cli.Command{
-		Name:  "create-milestone",
-		Usage: "create milestone for a project based on our config",
+		Name:      "create-milestone",
+		Usage:     "create milestone for a project based on our config",
+		ArgsUsage: "[project]",
 		Action: func(c *cli.Context) {
 			opts, err := NewOptions(c)
 			if err != nil {

--- a/project.go
+++ b/project.go
@@ -12,8 +12,9 @@ import (
 
 var (
 	showProjectsCommand = cli.Command{
-		Name:  "show-projects",
-		Usage: "output projects for user suitable for use in config",
+		Name:      "show-projects",
+		Usage:     "output projects for user suitable for use in config",
+		ArgsUsage: "[target]",
 		Action: func(c *cli.Context) {
 			opts, err := NewOptions(c)
 			if err != nil {


### PR DESCRIPTION
This will change the USAGE in the help message:

```
$ ./triage set-milestones --help
NAME:
   triage set-milestones - set milestones for a project based on our config

USAGE:
   triage set-milestones [project]
```

Currently the ones that do not have any params still contain `[arguments...]`. 
